### PR TITLE
Try to handle response body as a JSON first before handling it as a p…

### DIFF
--- a/lib/app_sources/html.dart
+++ b/lib/app_sources/html.dart
@@ -146,10 +146,7 @@ Future<List<MapEntry<String, String>>> grabLinksCommon(
       .map((e) => MapEntry(ensureAbsoluteUrl(e.key, reqUrl), e.value))
       .toList();
   if (allLinks.isEmpty || matchLinksOutsideATags) {
-    allLinks = getLinksInLines(rawBody);
-  }
-  if (allLinks.isEmpty) {
-    // Getting desperate
+    // Decode the body if the response is a JSON
     try {
       var jsonStrings = collectAllStringsFromJSONObject(jsonDecode(rawBody));
       allLinks = getLinksInLines(jsonStrings.join('\n'));
@@ -163,7 +160,7 @@ Future<List<MapEntry<String, String>>> grabLinksCommon(
         );
       }
     } catch (e) {
-      //
+      allLinks = getLinksInLines(rawBody);
     }
   }
   List<MapEntry<String, String>> links = [];


### PR DESCRIPTION
Hello,

I am trying to setup Instagram Lite in Obtainium by directly using the following API : https://www.instagram.com/api/v1/web/lite/

The API returns a JSON and the current implementation doesn't extract the full URL since it contains unescaped characters.

The proposed change rearranges the code to try to treat the body as a JSON first before treating it as plain text.  

Thank you!